### PR TITLE
add support for laravel v 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "guzzlehttp/guzzle": "^7.8.1",
-        "laravel/framework": "^7.0|^8.0|^9.0|^10|^11.0",
+        "laravel/framework": "^7.0|^8.0|^9.0|^10|^11.0|^12.0",
         "spatie/url": "^2.0",
         "ext-json": "*"
     },


### PR DESCRIPTION
@tobya This PR allows bcsapiwrapper to support laravel v12